### PR TITLE
Make sure KEY_ESC can be bound to keyboardmouse device.

### DIFF
--- a/src/uinput.c
+++ b/src/uinput.c
@@ -174,7 +174,7 @@ int open_uinput_keyboardmouse_fd(char* uinput_path) {
   /*Just set all possible keys that come before BTN_MISC
    * This should cover all reasonable keyboard keys.*/
   ioctl(fd, UI_SET_EVBIT, EV_KEY);
-  for (i = 2; i < BTN_MISC; i++) {
+  for (i = KEY_ESC; i < BTN_MISC; i++) {
     ioctl(fd, UI_SET_KEYBIT, i);
   }
   for (i = KEY_OK; i < KEY_MAX; i++) {


### PR DESCRIPTION
The original code started binding key values beginning with 2. Since KEY_ESC is defined as 1, the Escape key could not be bound to the home button on the Wiimote. This small change allows the Escape key to be bindable.
